### PR TITLE
Removed table borders for Github metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ I'm a self-taught passionate FrontEnd developer from India 🇮🇳
 <code><img height="20" src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/nodejs/nodejs.png"></code>    
 
 
-| <a href="https://github.com/anuraghazra/github-readme-stats"><img align="center" src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" /></a> | <a href="https://github.com/anuraghazra/github-readme-stats"><img align="center" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true" /></a> |
-| ------------- | ------------- |
+<p align="center"><a href="https://github.com/anuraghazra/github-readme-stats">
+<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="40.9%"/> </a>
+<a href="https://github.com/anuraghazra/github-readme-stats">
+<img width="56.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
+</p>
 
 #### Top Repositories
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ I'm a self-taught passionate FrontEnd developer from India 🇮🇳
 
 
 <p align="center"><a href="https://github.com/anuraghazra/github-readme-stats">
-<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="52.9%"/> </a>
+<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="53.1%"/> </a>
 <a href="https://github.com/anuraghazra/github-readme-stats">
-<img width="44.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
+<img width="44.7%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
 </p>
 
 #### Top Repositories

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ I'm a self-taught passionate FrontEnd developer from India 🇮🇳
 
 
 <p align="center"><a href="https://github.com/anuraghazra/github-readme-stats">
-<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="53.9%"/> </a>
+<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="52.9%"/> </a>
 <a href="https://github.com/anuraghazra/github-readme-stats">
-<img width="43.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
+<img width="44.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
 </p>
 
 #### Top Repositories

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ I'm a self-taught passionate FrontEnd developer from India 🇮🇳
 
 
 <p align="center"><a href="https://github.com/anuraghazra/github-readme-stats">
-<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="56.9%"/> </a>
+<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="53.9%"/> </a>
 <a href="https://github.com/anuraghazra/github-readme-stats">
-<img width="40.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
+<img width="43.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
 </p>
 
 #### Top Repositories

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ I'm a self-taught passionate FrontEnd developer from India 🇮🇳
 
 
 <p align="center"><a href="https://github.com/anuraghazra/github-readme-stats">
-<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="40.9%"/> </a>
+<img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&include_all_commits=true&theme=buefy&hide_border=true" alt="Anurag's github stats" width="56.9%"/> </a>
 <a href="https://github.com/anuraghazra/github-readme-stats">
-<img width="56.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
+<img width="40.9%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&layout=compact&theme=buefy&hide_border=true"  /></a>
 </p>
 
 #### Top Repositories


### PR DESCRIPTION
When I was working on my profile readme, I was facing the exact same thing ( I don't like the table borders at all, plus viewing them on smaller viewports is a pain.

Instead of that, I removed the table altogether and replaced it with inline images in a paragraph with their width set such that it would total up to ~96% of the total viewing width. This got rid of the table borders and its now properly aligned as well!

![image](https://user-images.githubusercontent.com/37407370/132690327-834c2fdb-4de5-4c55-965e-bb72a5dae17c.png)
